### PR TITLE
Update default hangar image to War Thunder logo

### DIFF
--- a/WarThunderRPC.py
+++ b/WarThunderRPC.py
@@ -11,6 +11,10 @@ import winreg
 import re
 from vehicle_images import VehicleImageResolver
 
+
+DEFAULT_LARGE_IMAGE_URL = "https://warthunder.com/assets/img/svg/logo-wt.svg"
+
+
 class WarThunderRPC:
     def __init__(self):
         self.client_id = "1211769535468937237"
@@ -214,7 +218,7 @@ class WarThunderRPC:
     def build_presence_data(self, state):
         base_presence = {
             "start": self.clock_timer,
-            "large_image": "logo",
+            "large_image": DEFAULT_LARGE_IMAGE_URL,
             "large_text": "War Thunder"
         }
 

--- a/service/warthunder_rpc_service.py
+++ b/service/warthunder_rpc_service.py
@@ -29,6 +29,9 @@ if PARENT_DIR not in sys.path:
 from vehicle_images import VehicleImageResolver
 
 
+DEFAULT_LARGE_IMAGE_URL = "https://warthunder.com/assets/img/svg/logo-wt.svg"
+
+
 log_dir = os.path.join(os.environ.get("PROGRAMDATA"), "WarThunderRPC")
 if not os.path.exists(log_dir):
     os.makedirs(log_dir)
@@ -397,7 +400,7 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
     def build_presence_data(self, state):
         base_presence = {
             "start": self.clock_timer,
-            "large_image": "logo",
+            "large_image": DEFAULT_LARGE_IMAGE_URL,
             "large_text": "War Thunder"
         }
 


### PR DESCRIPTION
## Summary
- introduce a shared `DEFAULT_LARGE_IMAGE_URL` constant in both the RPC client and service
- switch the default hangar large image key to the official War Thunder logo SVG URL
- keep the large text unchanged so the presence still reads "War Thunder"

## Testing
- Not run (not requested)