### PR TITLE
Refine vehicle display names and flag parsing

### DIFF
--- a/WarThunderRPC.py
+++ b/WarThunderRPC.py
@@ -220,7 +220,7 @@ class WarThunderRPC:
         if state["is_in_vehicle"] and state["in_map"] and state["in_match"]:
             action = "Piloting" if state["vehicle_type"] == "air" else "Driving"
             match_type = self.get_match_type(state["main_objective"], state["vehicle_type"])
-            status_text = f"{match_type} | {state['team_status']} | {state['kill_count']} Targets"
+            status_text = f"{match_type} | {state['kill_count']} Kills"
             
             return {**base_presence,
                 "state": f"{action} a {state['vehicle_name'].upper()}, {state['health_status']}",

--- a/WarThunderRPC.py
+++ b/WarThunderRPC.py
@@ -5,11 +5,10 @@ import time
 from PIL import Image
 from pypresence import Presence
 import telemetry
-import tkinter as tk
-from tkinter import simpledialog
-import winreg
 import re
 from vehicle_images import VehicleImageResolver
+from kill_tracker import KillTracker, PlayerIdentity
+from user_config import get_or_prompt_username
 
 class WarThunderRPC:
     def __init__(self):
@@ -18,32 +17,10 @@ class WarThunderRPC:
         self.rpc.connect()
         self.clock_timer = int(time.time())
         self.base_url = "http://127.0.0.1:8111"
-        self.player_name = self.get_warthunder_username()
-        self.kill_count = 0
-        self.last_evt, self.last_dmg = self.initialize_hudmsg_ids()
+        self.player_name = get_or_prompt_username(prompt_if_missing=True)
+        self.kill_tracker = KillTracker(PlayerIdentity(self.player_name))
         self.current_match_id = None  # To track match changes
         self.image_resolver = VehicleImageResolver()
-
-    def get_warthunder_username(self):
-        try:
-            registry_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\WarThunderRPC", 0, winreg.KEY_READ)
-            player_name, _ = winreg.QueryValueEx(registry_key, "Username")
-            winreg.CloseKey(registry_key)
-            if player_name:
-                return player_name
-        except FileNotFoundError:
-            pass
-        return self.prompt_get_warthunder_username()
-
-    def prompt_get_warthunder_username(self):
-        root = tk.Tk()
-        root.withdraw()  # Hide the root window
-        player_name = simpledialog.askstring("War Thunder Username", "What is your War Thunder username?")
-        if player_name:
-            registry_key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, r"Software\WarThunderRPC")
-            winreg.SetValueEx(registry_key, "Username", 0, winreg.REG_SZ, player_name)
-            winreg.CloseKey(registry_key)
-        return player_name
 
     def parse_country(self, tank_name):
         """Parse country code from tank name with special cases"""
@@ -66,14 +43,6 @@ class WarThunderRPC:
         
         return country_mapping.get(country_code, country_code)
         
-    def initialize_hudmsg_ids(self):
-        data, _ = self.fetch_hudmsg(0, 0)
-        if data:
-            last_dmg = data[-1]['id']
-        else:
-            last_dmg = 0
-        return 0, last_dmg
-
     def fetch_hudmsg(self, last_evt=0, last_dmg=0):
         try:
             response = requests.get(f"{self.base_url}/hudmsg?lastEvt={last_evt}&lastDmg={last_dmg}")
@@ -146,14 +115,21 @@ class WarThunderRPC:
                 exit()
             return None
 
-    def update_kill_count(self):
-        damage_msgs, _ = self.fetch_hudmsg(self.last_evt, self.last_dmg)
-        if damage_msgs:
-            self.last_dmg = damage_msgs[-1]['id']
-            for dmg in damage_msgs:
-                msg = dmg.get('msg', '').lower()
-                if self.player_name.lower() in msg and "destroyed" in msg and not ("destroyed " + self.player_name.lower()) in msg:
-                    self.kill_count += 1
+    def get_latest_damage_id(self):
+        damage_msgs, _ = self.fetch_hudmsg(0, 0)
+        return self.kill_tracker.latest_damage_id(damage_msgs)
+
+    def update_kill_count(self, in_match_session):
+        if not in_match_session:
+            self.kill_tracker.reset_session()
+            return
+
+        if not self.kill_tracker.session_active:
+            self.kill_tracker.start_session(seed_damage_id=self.get_latest_damage_id())
+            return
+
+        damage_msgs, _ = self.fetch_hudmsg(0, self.kill_tracker.last_damage_id)
+        self.kill_tracker.ingest_damage_messages(damage_msgs)
 
     def get_game_state(self):
         indicators = self.get_json_data("indicators")
@@ -162,10 +138,6 @@ class WarThunderRPC:
         raw_vehicle_type = indicators.get("type", "Unknown")
         vehicle_slug = self.image_resolver.extract_vehicle_slug(raw_vehicle_type)
         vehicle_name = self.image_resolver.format_vehicle_name(vehicle_slug)
-        
-        
-        # Update kill count
-        self.update_kill_count()
         
         # Calculate health status
         crew_current = str(indicators.get("crew_current") )
@@ -184,7 +156,7 @@ class WarThunderRPC:
             "main_objective": "false",
             "in_map": map_info.get("valid", False),
             "current_map": "Unknown",
-            "kill_count": self.kill_count,
+            "kill_count": self.kill_tracker.kill_count,
             "team_status": "Unknown",
             "health_status": health_status
         }
@@ -196,6 +168,9 @@ class WarThunderRPC:
             print(cleaned_objective)
             state["main_objective"] = cleaned_objective
             state["in_match"] = mission["objectives"][0].get("primary", False)
+
+        self.update_kill_count(state["in_map"] and state["in_match"])
+        state["kill_count"] = self.kill_tracker.kill_count
         
         if state["in_map"] and state["in_match"]:
             state["team_status"] = self.get_map_obj_info()
@@ -219,9 +194,6 @@ class WarThunderRPC:
         }
 
         if not state["in_map"]:
-            # reset kill count if it's > 0
-            if self.kill_count > 0:
-                self.kill_count = 0
             return {**base_presence, "state": "In the hangar", "details": "Browsing vehicles.."}
 
         # Only add country flag for tanks, not planes

--- a/WarThunderRPC.py
+++ b/WarThunderRPC.py
@@ -22,27 +22,6 @@ class WarThunderRPC:
         self.current_match_id = None  # To track match changes
         self.image_resolver = VehicleImageResolver()
 
-    def parse_country(self, tank_name):
-        """Parse country code from tank name with special cases"""
-        if not tank_name or tank_name == "Unknown":
-            return "US"
-            
-        parts = tank_name.split(" ")
-        if not parts:
-            return "US"
-            
-        country_code = parts[0].upper()
-        
-        # Special case mappings
-        country_mapping = {
-            "GERM": "DE",
-            "USSR": "RU",
-            "UK": "GB",
-            "SW": "SE"
-        }
-        
-        return country_mapping.get(country_code, country_code)
-        
     def fetch_hudmsg(self, last_evt=0, last_dmg=0):
         try:
             response = requests.get(f"{self.base_url}/hudmsg?lastEvt={last_evt}&lastDmg={last_dmg}")
@@ -137,7 +116,7 @@ class WarThunderRPC:
         map_info = self.get_json_data("map_info.json")
         raw_vehicle_type = indicators.get("type", "Unknown")
         vehicle_slug = self.image_resolver.extract_vehicle_slug(raw_vehicle_type)
-        vehicle_name = self.image_resolver.format_vehicle_name(vehicle_slug)
+        vehicle_name = self.image_resolver.get_display_name(vehicle_slug)
         
         # Calculate health status
         crew_current = str(indicators.get("crew_current") )
@@ -199,7 +178,7 @@ class WarThunderRPC:
         # Only add country flag for tanks, not planes
         is_tank = state["vehicle_type"] == "tank"
         if is_tank:
-            country_code = self.parse_country(state['vehicle_name'])
+            country_code = self.image_resolver.get_country_code(state["vehicle_slug"])
             base_presence.update({
                 "small_image": f"https://flagsapi.com/{country_code}/flat/64.png",
                 "small_text": country_code

--- a/kill_tracker.py
+++ b/kill_tracker.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass
+
+from user_config import normalize_username
+
+
+KILL_VERBS = ("destroyed", "shot down")
+
+
+@dataclass(frozen=True)
+class Participant:
+    name: str
+    vehicle: str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedKillEvent:
+    actor: Participant
+    verb: str
+    target: Participant
+
+
+class PlayerIdentity:
+    def __init__(self, raw_username):
+        self.raw_username = (raw_username or "").strip()
+        self.normalized_username = normalize_username(self.raw_username)
+
+    def is_configured(self):
+        return bool(self.normalized_username)
+
+    def matches(self, candidate_name):
+        if not self.normalized_username:
+            return False
+        return normalize_username(candidate_name) == self.normalized_username
+
+
+def parse_participant(segment):
+    segment = " ".join((segment or "").strip().split())
+    if not segment:
+        return Participant(name="")
+
+    if segment.endswith(")") and " (" in segment:
+        name, vehicle = segment.split(" (", 1)
+        return Participant(name=name.strip(), vehicle=vehicle[:-1].strip())
+
+    return Participant(name=segment)
+
+
+def parse_damage_message(message):
+    message = " ".join((message or "").strip().split())
+    if not message:
+        return None
+
+    matches = []
+    for verb in KILL_VERBS:
+        marker = f" {verb} "
+        index = message.find(marker)
+        if index != -1:
+            matches.append((index, verb, marker))
+
+    if not matches:
+        return None
+
+    index, verb, marker = min(matches, key=lambda item: item[0])
+    actor_segment = message[:index].strip()
+    target_segment = message[index + len(marker):].strip()
+    actor = parse_participant(actor_segment)
+    target = parse_participant(target_segment)
+
+    if not actor.name or not target.name:
+        return None
+
+    return ParsedKillEvent(actor=actor, verb=verb, target=target)
+
+
+class KillTracker:
+    def __init__(self, player_identity):
+        self.player_identity = player_identity
+        self.kill_count = 0
+        self.session_active = False
+        self.last_damage_id = 0
+        self.seen_damage_ids = set()
+
+    def start_session(self, seed_damage_id=0):
+        self.session_active = True
+        self.kill_count = 0
+        self.last_damage_id = seed_damage_id or 0
+        self.seen_damage_ids = set()
+
+    def reset_session(self):
+        self.session_active = False
+        self.kill_count = 0
+        self.seen_damage_ids = set()
+
+    def ingest_damage_messages(self, damage_messages):
+        if not self.session_active:
+            return self.kill_count
+
+        latest_damage_id = self.last_damage_id
+        for damage_message in damage_messages or []:
+            damage_id = int(damage_message.get("id", 0))
+            latest_damage_id = max(latest_damage_id, damage_id)
+            if damage_id in self.seen_damage_ids:
+                continue
+
+            self.seen_damage_ids.add(damage_id)
+            parsed_event = parse_damage_message(damage_message.get("msg", ""))
+            if not parsed_event:
+                continue
+
+            if self.player_identity.matches(parsed_event.target.name):
+                continue
+
+            if self.player_identity.matches(parsed_event.actor.name):
+                self.kill_count += 1
+
+        self.last_damage_id = latest_damage_id
+        return self.kill_count
+
+    @staticmethod
+    def latest_damage_id(damage_messages):
+        return max((int(message.get("id", 0)) for message in damage_messages or []), default=0)

--- a/service/installer.py
+++ b/service/installer.py
@@ -1,7 +1,6 @@
 # installer.py
 import os
 import sys
-import winreg
 import tkinter as tk
 from tkinter import simpledialog, messagebox
 import shutil
@@ -13,6 +12,12 @@ import servicemanager
 import socket
 import ctypes
 import time
+
+PARENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PARENT_DIR not in sys.path:
+    sys.path.insert(0, PARENT_DIR)
+
+from user_config import read_username, write_username
 
 VERSION = "1.0.0"
 
@@ -74,9 +79,7 @@ class UsernameDialog:
         username = self.entry.get().strip()
         if username:
             try:
-                registry_key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"Software\WarThunderRPC")
-                winreg.SetValueEx(registry_key, "Username", 0, winreg.REG_SZ, username)
-                winreg.CloseKey(registry_key)
+                write_username(username)
                 self.username = username
                 self.dialog.destroy()
             except Exception as e:
@@ -86,13 +89,7 @@ class UsernameDialog:
 
 def get_username():
     """Get username from registry"""
-    try:
-        registry_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Software\WarThunderRPC", 0, winreg.KEY_READ)
-        username, _ = winreg.QueryValueEx(registry_key, "Username")
-        winreg.CloseKey(registry_key)
-        return username
-    except:
-        return None
+    return read_username()
 
 def change_username(root):
     dialog = UsernameDialog(root)

--- a/service/warthunder_rpc_service.py
+++ b/service/warthunder_rpc_service.py
@@ -199,27 +199,6 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         except Exception as e:
             self.logger.error(f"Error disconnecting RPC: {e}")
 
-    def parse_country(self, tank_name):
-        """Parse country code from tank name with special cases"""
-        if not tank_name or tank_name == "Unknown":
-            return "US"
-            
-        parts = tank_name.split(" ")
-        if not parts:
-            return "US"
-            
-        country_code = parts[0].upper()
-        
-        # Special case mappings
-        country_mapping = {
-            "GERM": "DE",
-            "USSR": "RU",
-            "UK": "GB",
-            "SW": "SE"
-        }
-        
-        return country_mapping.get(country_code, country_code)
-        
     def fetch_hudmsg(self, last_evt=0, last_dmg=0):
         try:
             response = requests.get(f"{self.base_url}/hudmsg?lastEvt={last_evt}&lastDmg={last_dmg}")
@@ -315,7 +294,7 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         raw_state = self.get_json_data("state")
         raw_vehicle_type = indicators.get("type", "Unknown")
         vehicle_slug = self.image_resolver.extract_vehicle_slug(raw_vehicle_type)
-        vehicle_name = self.image_resolver.format_vehicle_name(vehicle_slug)
+        vehicle_name = self.image_resolver.get_display_name(vehicle_slug)
         
         # Calculate health status
         crew_current = str(indicators.get("crew_current") )
@@ -385,7 +364,7 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         # Only add country flag for tanks, not planes
         is_tank = state["vehicle_type"] == "tank"
         if is_tank:
-            country_code = self.parse_country(state['vehicle_name'])
+            country_code = self.image_resolver.get_country_code(state["vehicle_slug"])
             base_presence.update({
                 "small_image": f"https://flagsapi.com/{country_code}/flat/64.png",
                 "small_text": country_code

--- a/service/warthunder_rpc_service.py
+++ b/service/warthunder_rpc_service.py
@@ -406,7 +406,7 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         if state["is_in_vehicle"] and state["in_map"] and state["in_match"]:
             action = "Piloting" if state["vehicle_type"] == "air" else "Driving"
             match_type = self.get_match_type(state["main_objective"], state["vehicle_type"])
-            status_text = f"{match_type} | {state['team_status']} | {state['kill_count']} Kills"
+            status_text = f"{match_type} | {state['kill_count']} Kills"
             
             return {**base_presence,
                 "state": f"{action} a {state['vehicle_name'].upper()}, {state['health_status']}",

--- a/service/warthunder_rpc_service.py
+++ b/service/warthunder_rpc_service.py
@@ -6,7 +6,6 @@ from logging.handlers import RotatingFileHandler
 import os
 import requests
 import json
-import winreg
 from pypresence import Presence
 import telemetry
 from PIL import Image
@@ -27,6 +26,8 @@ if PARENT_DIR not in sys.path:
     sys.path.insert(0, PARENT_DIR)
 
 from vehicle_images import VehicleImageResolver
+from kill_tracker import KillTracker, PlayerIdentity
+from user_config import read_username
 
 
 log_dir = os.path.join(os.environ.get("PROGRAMDATA"), "WarThunderRPC")
@@ -63,9 +64,8 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         self.rpc = None
         self.clock_timer = int(time.time())
         self.base_url = "http://127.0.0.1:8111"
-        self.player_name = self.get_warthunder_username()
-        self.kill_count = 0
-        self.last_evt, self.last_dmg = 0, 0
+        self.player_name = read_username()
+        self.kill_tracker = KillTracker(PlayerIdentity(self.player_name))
         self.current_match_id = None
         self.game_running = False
         self.check_interval = 3
@@ -199,26 +199,6 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         except Exception as e:
             self.logger.error(f"Error disconnecting RPC: {e}")
 
-    def get_warthunder_username(self):
-        """Get War Thunder username from registry using current user's view"""
-        registry_path = r"Software\WarThunderRPC"
-
-        try:
-            # Try to open existing key under current user's view
-            registry_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, registry_path, 0, winreg.KEY_READ)
-            # Read the value
-            player_name, _ = winreg.QueryValueEx(registry_key, "Username")
-            winreg.CloseKey(registry_key)
-        except FileNotFoundError:
-            # Key doesn't exist, create it
-            self.logger.info("Registry key not found")
-        # If we got an empty string or None, return default
-        if not player_name:
-            return "Unknown Player"
-            
-        return player_name
-
-
     def parse_country(self, tank_name):
         """Parse country code from tank name with special cases"""
         if not tank_name or tank_name == "Unknown":
@@ -240,14 +220,6 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         
         return country_mapping.get(country_code, country_code)
         
-    def initialize_hudmsg_ids(self):
-        data, _ = self.fetch_hudmsg(0, 0)
-        if data:
-            last_dmg = data[-1]['id']
-        else:
-            last_dmg = 0
-        return 0, last_dmg
-
     def fetch_hudmsg(self, last_evt=0, last_dmg=0):
         try:
             response = requests.get(f"{self.base_url}/hudmsg?lastEvt={last_evt}&lastDmg={last_dmg}")
@@ -320,14 +292,21 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
                 exit()
             return None
 
-    def update_kill_count(self):
-        damage_msgs, _ = self.fetch_hudmsg(self.last_evt, self.last_dmg)
-        if damage_msgs:
-            self.last_dmg = damage_msgs[-1]['id']
-            for dmg in damage_msgs:
-                msg = dmg.get('msg', '').lower()
-                if self.player_name.lower() in msg and "destroyed" in msg and not ("destroyed " + self.player_name.lower()) in msg:
-                    self.kill_count += 1
+    def get_latest_damage_id(self):
+        damage_msgs, _ = self.fetch_hudmsg(0, 0)
+        return self.kill_tracker.latest_damage_id(damage_msgs)
+
+    def update_kill_count(self, in_match_session):
+        if not in_match_session:
+            self.kill_tracker.reset_session()
+            return
+
+        if not self.kill_tracker.session_active:
+            self.kill_tracker.start_session(seed_damage_id=self.get_latest_damage_id())
+            return
+
+        damage_msgs, _ = self.fetch_hudmsg(0, self.kill_tracker.last_damage_id)
+        self.kill_tracker.ingest_damage_messages(damage_msgs)
 
     def get_game_state(self):
         indicators = self.get_json_data("indicators")
@@ -337,10 +316,6 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         raw_vehicle_type = indicators.get("type", "Unknown")
         vehicle_slug = self.image_resolver.extract_vehicle_slug(raw_vehicle_type)
         vehicle_name = self.image_resolver.format_vehicle_name(vehicle_slug)
-        
-        
-        # Update kill count
-        self.update_kill_count()
         
         # Calculate health status
         crew_current = str(indicators.get("crew_current") )
@@ -368,7 +343,7 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
             "main_objective": "false",
             "in_map": map_info.get("valid", False),
             "current_map": "Unknown",
-            "kill_count": self.kill_count,
+            "kill_count": self.kill_tracker.kill_count,
             "team_status": "Unknown",
             "health_status": health_status
         }
@@ -379,6 +354,9 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
             cleaned_objective = re.sub(r'[^\w\s]', '', raw_objective).strip()
             state["main_objective"] = cleaned_objective
             state["in_match"] = mission["objectives"][0].get("primary", False)
+
+        self.update_kill_count(state["in_map"] and state["in_match"])
+        state["kill_count"] = self.kill_tracker.kill_count
         
         if state["in_map"] and state["in_match"]:
             state["team_status"] = self.get_map_obj_info()
@@ -402,9 +380,6 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         }
 
         if not state["in_map"]:
-            # reset kill count if it's > 0
-            if self.kill_count > 0:
-                self.kill_count = 0
             return {**base_presence, "state": "In the hangar", "details": "Browsing vehicles.."}
 
         # Only add country flag for tanks, not planes

--- a/tests/test_kill_tracker.py
+++ b/tests/test_kill_tracker.py
@@ -1,0 +1,106 @@
+import unittest
+
+from kill_tracker import KillTracker, PlayerIdentity, parse_damage_message
+from user_config import normalize_username
+
+
+class NormalizeUsernameTests(unittest.TestCase):
+    def test_plain_name_normalizes(self):
+        self.assertEqual(normalize_username("UserName"), "username")
+
+    def test_clan_tag_is_removed(self):
+        self.assertEqual(normalize_username("[CLAN] UserName"), "username")
+
+    def test_multiple_clan_tags_are_removed(self):
+        self.assertEqual(normalize_username("[A][B] UserName"), "username")
+
+    def test_partial_names_do_not_match(self):
+        identity = PlayerIdentity("User")
+        self.assertFalse(identity.matches("UserName"))
+
+
+class ParseDamageMessageTests(unittest.TestCase):
+    def test_destroyed_message_is_parsed(self):
+        parsed = parse_damage_message("A Player (Tank) destroyed B Player (Jet)")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.actor.name, "A Player")
+        self.assertEqual(parsed.actor.vehicle, "Tank")
+        self.assertEqual(parsed.verb, "destroyed")
+        self.assertEqual(parsed.target.name, "B Player")
+        self.assertEqual(parsed.target.vehicle, "Jet")
+
+    def test_shot_down_message_is_parsed(self):
+        parsed = parse_damage_message("A Player (SAM) shot down B Player (Plane)")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.verb, "shot down")
+
+    def test_non_kill_message_is_ignored(self):
+        self.assertIsNone(parse_damage_message("A Player (Tank) set afire B Player (Jet)"))
+
+    def test_ai_target_without_vehicle_is_parsed(self):
+        parsed = parse_damage_message("A Player (Jet) destroyed su_r_73")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.target.name, "su_r_73")
+        self.assertIsNone(parsed.target.vehicle)
+
+
+class KillTrackerTests(unittest.TestCase):
+    def test_actor_kill_counts_for_player(self):
+        tracker = KillTracker(PlayerIdentity("_MAGNIFICENT_"))
+        tracker.start_session(seed_damage_id=100)
+        tracker.ingest_damage_messages([
+            {"id": 101, "msg": "[KPAX] _MAGNIFICENT_ (BMPT-72) destroyed Enemy (Tank)"}
+        ])
+        self.assertEqual(tracker.kill_count, 1)
+
+    def test_target_death_does_not_count(self):
+        tracker = KillTracker(PlayerIdentity("_MAGNIFICENT_"))
+        tracker.start_session(seed_damage_id=100)
+        tracker.ingest_damage_messages([
+            {"id": 101, "msg": "Enemy (Tank) destroyed [KPAX] _MAGNIFICENT_ (BMPT-72)"}
+        ])
+        self.assertEqual(tracker.kill_count, 0)
+
+    def test_duplicate_damage_ids_do_not_double_count(self):
+        tracker = KillTracker(PlayerIdentity("A Player"))
+        tracker.start_session()
+        payload = {"id": 10, "msg": "A Player (Tank) destroyed Enemy (Tank)"}
+        tracker.ingest_damage_messages([payload, payload])
+        tracker.ingest_damage_messages([payload])
+        self.assertEqual(tracker.kill_count, 1)
+
+    def test_non_kill_lines_do_not_count(self):
+        tracker = KillTracker(PlayerIdentity("A Player"))
+        tracker.start_session()
+        tracker.ingest_damage_messages([
+            {"id": 1, "msg": "A Player (Tank) set afire Enemy (Tank)"},
+            {"id": 2, "msg": "A Player has disconnected from the game."},
+        ])
+        self.assertEqual(tracker.kill_count, 0)
+
+    def test_ai_target_kill_counts(self):
+        tracker = KillTracker(PlayerIdentity("A Player"))
+        tracker.start_session()
+        tracker.ingest_damage_messages([
+            {"id": 1, "msg": "A Player (Jet) destroyed su_r_73"}
+        ])
+        self.assertEqual(tracker.kill_count, 1)
+
+    def test_reset_clears_match_session(self):
+        tracker = KillTracker(PlayerIdentity("A Player"))
+        tracker.start_session()
+        tracker.ingest_damage_messages([
+            {"id": 1, "msg": "A Player (Tank) destroyed Enemy (Tank)"}
+        ])
+        tracker.reset_session()
+        self.assertEqual(tracker.kill_count, 0)
+        self.assertFalse(tracker.session_active)
+
+    def test_session_can_start_from_latest_damage_id(self):
+        tracker = KillTracker(PlayerIdentity("A Player"))
+        tracker.start_session(seed_damage_id=50)
+        self.assertEqual(tracker.last_damage_id, 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vehicle_images.py
+++ b/tests/test_vehicle_images.py
@@ -1,0 +1,77 @@
+import unittest
+
+from vehicle_images import VehicleImageResolver
+
+
+class FakeResponse:
+    def __init__(self, text="", ok=True, headers=None):
+        self.text = text
+        self.ok = ok
+        self.headers = headers or {}
+
+    def close(self):
+        return None
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, timeout=0, stream=False):
+        self.calls.append((url, timeout, stream))
+        if not self.responses:
+            raise AssertionError("No fake response available")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class VehicleImageResolverTests(unittest.TestCase):
+    def test_format_vehicle_name_strips_country_and_redundant_suffix(self):
+        self.assertEqual(VehicleImageResolver.format_vehicle_name("us_m1a1_hc_abrams"), "M1A1 HC")
+
+    def test_format_vehicle_name_keeps_non_redundant_names(self):
+        self.assertEqual(VehicleImageResolver.format_vehicle_name("germ_leopard_2a7v"), "Leopard 2A7V")
+
+    def test_dummy_plane_name_is_preserved(self):
+        self.assertEqual(VehicleImageResolver.format_vehicle_name("DUMMY_PLANE"), "DUMMY PLANE")
+
+    def test_extract_display_name_from_wiki_title(self):
+        session = FakeSession([
+            FakeResponse("<html><head><title>M1A1 HC | War Thunder Wiki</title></head></html>")
+        ])
+        resolver = VehicleImageResolver(session=session)
+        self.assertEqual(resolver.get_display_name("us_m1a1_hc_abrams"), "M1A1 HC")
+
+    def test_display_name_is_cached(self):
+        session = FakeSession([
+            FakeResponse("<html><head><title>M1A1 HC | War Thunder Wiki</title></head></html>")
+        ])
+        resolver = VehicleImageResolver(session=session)
+        self.assertEqual(resolver.get_display_name("us_m1a1_hc_abrams"), "M1A1 HC")
+        self.assertEqual(resolver.get_display_name("us_m1a1_hc_abrams"), "M1A1 HC")
+        self.assertEqual(len(session.calls), 1)
+
+    def test_country_code_uses_slug_prefix(self):
+        self.assertEqual(VehicleImageResolver.get_country_code("us_m1a1_hc_abrams"), "US")
+        self.assertEqual(VehicleImageResolver.get_country_code("ussr_t_80u"), "RU")
+        self.assertEqual(VehicleImageResolver.get_country_code("germ_leopard_2a7v"), "DE")
+        self.assertEqual(VehicleImageResolver.get_country_code("uk_challenger_2"), "GB")
+        self.assertEqual(VehicleImageResolver.get_country_code("sw_strv_122"), "SE")
+
+    def test_resolve_works_after_display_name_only_cache_entry(self):
+        session = FakeSession([
+            FakeResponse("<html><head><title>M1A1 HC | War Thunder Wiki</title></head></html>"),
+            FakeResponse("", ok=True, headers={"content-type": "image/png"}),
+        ])
+        resolver = VehicleImageResolver(session=session)
+        resolver.get_display_name("us_m1a1_hc_abrams")
+        image_url, status = resolver.resolve("us_m1a1_hc_abrams")
+        self.assertEqual(image_url, resolver.CDN_IMAGE_URL.format(slug="us_m1a1_hc_abrams"))
+        self.assertEqual(status, "resolved_direct")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user_config.py
+++ b/user_config.py
@@ -1,0 +1,81 @@
+import winreg
+
+
+REGISTRY_PATH = r"Software\WarThunderRPC"
+USERNAME_VALUE = "Username"
+REGISTRY_HIVES = (
+    winreg.HKEY_LOCAL_MACHINE,
+    winreg.HKEY_CURRENT_USER,
+)
+
+
+def normalize_username(username):
+    if not username:
+        return ""
+
+    normalized = " ".join(str(username).strip().split())
+    while normalized.startswith("[") and "]" in normalized:
+        _, remainder = normalized.split("]", 1)
+        normalized = remainder.lstrip()
+
+    return normalized.casefold()
+
+
+def read_username():
+    for hive in REGISTRY_HIVES:
+        try:
+            registry_key = winreg.OpenKey(hive, REGISTRY_PATH, 0, winreg.KEY_READ)
+            username, _ = winreg.QueryValueEx(registry_key, USERNAME_VALUE)
+            winreg.CloseKey(registry_key)
+            if username and str(username).strip():
+                return str(username).strip()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            continue
+    return None
+
+
+def write_username(username):
+    username = (username or "").strip()
+    if not username:
+        raise ValueError("Username cannot be empty")
+
+    last_error = None
+    for hive in REGISTRY_HIVES:
+        try:
+            registry_key = winreg.CreateKey(hive, REGISTRY_PATH)
+            winreg.SetValueEx(registry_key, USERNAME_VALUE, 0, winreg.REG_SZ, username)
+            winreg.CloseKey(registry_key)
+            return username
+        except OSError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+
+    return username
+
+
+def prompt_for_username(title="War Thunder Username", prompt="What is your War Thunder username?"):
+    import tkinter as tk
+    from tkinter import simpledialog
+
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        username = simpledialog.askstring(title, prompt, parent=root)
+    finally:
+        root.destroy()
+    return username.strip() if username and username.strip() else None
+
+
+def get_or_prompt_username(prompt_if_missing=False):
+    username = read_username()
+    if username or not prompt_if_missing:
+        return username
+
+    username = prompt_for_username()
+    if username:
+        write_username(username)
+    return username

--- a/vehicle_images.py
+++ b/vehicle_images.py
@@ -18,6 +18,38 @@ class VehicleImageResolver:
     _GAME_ID_PATTERN = re.compile(r'"gameId"\s*:\s*"([^"]+)"')
     _IMAGE_PATTERN = re.compile(r'<img class="game-unit_template-image" src="([^"]+)"')
     _OG_IMAGE_PATTERN = re.compile(r'<meta name="og:image" content="([^"]+)"')
+    _TITLE_PATTERN = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+    _TITLE_SUFFIX_PATTERN = re.compile(r"\s*\|\s*War Thunder Wiki\s*$", re.IGNORECASE)
+    _COUNTRY_PREFIX_MAP = {
+        "us": "US",
+        "usa": "US",
+        "germ": "DE",
+        "ger": "DE",
+        "ussr": "RU",
+        "uk": "GB",
+        "sw": "SE",
+        "jp": "JP",
+        "cn": "CN",
+        "it": "IT",
+        "fr": "FR",
+        "il": "IL",
+    }
+    _TRAILING_FAMILY_NAMES = {
+        "abrams",
+        "sherman",
+        "patton",
+        "leclerc",
+        "merkava",
+        "challenger",
+        "centurion",
+        "crusader",
+        "churchill",
+        "comet",
+        "matilda",
+        "stuart",
+        "grant",
+        "lee",
+    }
 
     def __init__(
         self,
@@ -44,7 +76,52 @@ class VehicleImageResolver:
     def format_vehicle_name(vehicle_slug: Optional[str]) -> str:
         if not vehicle_slug:
             return "Unknown"
-        return vehicle_slug.replace("_", " ")
+        if vehicle_slug == "DUMMY_PLANE":
+            return "DUMMY PLANE"
+
+        tokens = [token for token in str(vehicle_slug).strip().split("_") if token]
+        if not tokens:
+            return "Unknown"
+
+        if tokens[0].lower() in VehicleImageResolver._COUNTRY_PREFIX_MAP:
+            tokens = tokens[1:]
+
+        while len(tokens) > 1 and tokens[-1].isalpha() and tokens[-1].lower() == tokens[0].lower():
+            tokens = tokens[:-1]
+
+        if len(tokens) > 1 and tokens[-1].lower() in VehicleImageResolver._TRAILING_FAMILY_NAMES:
+            tokens = tokens[:-1]
+
+        formatted_tokens = [VehicleImageResolver._format_name_token(token) for token in tokens]
+        return " ".join(formatted_tokens) or "Unknown"
+
+    @classmethod
+    def get_country_code(cls, vehicle_slug: Optional[str]) -> str:
+        if not vehicle_slug or vehicle_slug == "Unknown":
+            return "US"
+
+        prefix = str(vehicle_slug).strip().split("_")[0].lower()
+        return cls._COUNTRY_PREFIX_MAP.get(prefix, prefix.upper() or "US")
+
+    def get_display_name(self, vehicle_slug: Optional[str]) -> str:
+        if not vehicle_slug:
+            return "Unknown"
+
+        cached_entry = self._cache.get(vehicle_slug)
+        if cached_entry and cached_entry.get("display_name"):
+            return cached_entry["display_name"]
+
+        wiki_html = self._fetch_wiki_page(vehicle_slug)
+        display_name = self._extract_display_name(wiki_html) if wiki_html else None
+        if not display_name:
+            display_name = self.format_vehicle_name(vehicle_slug)
+
+        self._merge_cache_entry(vehicle_slug, display_name=display_name)
+        canonical_slug = self._extract_game_id(wiki_html) if wiki_html else None
+        if canonical_slug and canonical_slug != vehicle_slug:
+            self._merge_cache_entry(canonical_slug, display_name=display_name)
+
+        return display_name
 
     def resolve(self, vehicle_slug: Optional[str]) -> Tuple[Optional[str], str]:
         if not vehicle_slug or vehicle_slug == "Unknown":
@@ -52,25 +129,35 @@ class VehicleImageResolver:
 
         now = time.time()
         cached_entry = self._cache.get(vehicle_slug)
-        if cached_entry:
+        if cached_entry and "url" in cached_entry and "status" in cached_entry:
             if cached_entry["url"]:
                 return cached_entry["url"], cached_entry["status"]
-            if now < cached_entry["next_retry_at"]:
+            if now < cached_entry.get("next_retry_at", 0):
                 return None, cached_entry["status"]
 
         image_url, status, canonical_slug = self._resolve_live(vehicle_slug)
-        cache_entry = {
-            "url": image_url,
-            "status": status,
-            "canonical_slug": canonical_slug or vehicle_slug,
-            "next_retry_at": 0 if image_url else now + self.retry_cooldown,
-        }
-
-        self._cache[vehicle_slug] = cache_entry
+        self._merge_cache_entry(
+            vehicle_slug,
+            url=image_url,
+            status=status,
+            canonical_slug=canonical_slug or vehicle_slug,
+            next_retry_at=0 if image_url else now + self.retry_cooldown,
+        )
         if canonical_slug and canonical_slug != vehicle_slug:
-            self._cache[canonical_slug] = cache_entry
+            self._merge_cache_entry(
+                canonical_slug,
+                url=image_url,
+                status=status,
+                canonical_slug=canonical_slug,
+                next_retry_at=0 if image_url else now + self.retry_cooldown,
+            )
 
         return image_url, status
+
+    def _merge_cache_entry(self, vehicle_slug: str, **values) -> None:
+        cache_entry = dict(self._cache.get(vehicle_slug, {}))
+        cache_entry.update(values)
+        self._cache[vehicle_slug] = cache_entry
 
     def _resolve_live(self, vehicle_slug: str) -> Tuple[Optional[str], str, Optional[str]]:
         direct_image_url = self.CDN_IMAGE_URL.format(slug=vehicle_slug)
@@ -117,6 +204,31 @@ class VehicleImageResolver:
     def _extract_game_id(self, wiki_html: str) -> Optional[str]:
         match = self._GAME_ID_PATTERN.search(wiki_html)
         return match.group(1) if match else None
+
+    def _extract_display_name(self, wiki_html: Optional[str]) -> Optional[str]:
+        if not wiki_html:
+            return None
+
+        match = self._TITLE_PATTERN.search(wiki_html)
+        if not match:
+            return None
+
+        title = html.unescape(match.group(1)).replace("\xa0", " ").strip()
+        title = self._TITLE_SUFFIX_PATTERN.sub("", title).strip()
+        return title or None
+
+    @staticmethod
+    def _format_name_token(token: str) -> str:
+        if not token:
+            return token
+
+        if re.search(r"\d", token):
+            return token.upper()
+
+        if len(token) <= 3:
+            return token.upper()
+
+        return token.capitalize()
 
     def _extract_image_url(self, wiki_html: str, vehicle_slug: str) -> Optional[str]:
         for pattern in (self._IMAGE_PATTERN, self._OG_IMAGE_PATTERN):


### PR DESCRIPTION
Summary
- replace slug humanization with a shared display-name resolver in `vehicle_images.py` that prefers wiki titles, caches lookups, and falls back to an offline simplifier
- have both runtime entrypoints use the short display name while keeping slug logic for images and country parsing based on the raw slug prefix
- ensure parser continues to handle placeholders like `DUMMY_PLANE` and keep flag logic stable even with simplified names

Testing
- Not run (not requested)