### PR TITLE
Harden runtime supervision and Discord handling

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,7 +1,83 @@
+import logging
 import unittest
 from unittest.mock import patch
 
 from warthunder_rpc.runtime import RuntimeOptions, WarThunderRPCApp
+from warthunder_rpc.windows_service import WarThunderRPCService
+
+
+class FakeClock:
+    def __init__(self, start=100.0):
+        self.current = float(start)
+
+    def now(self):
+        return self.current
+
+    def sleep(self, seconds):
+        self.current += float(seconds)
+
+    def advance(self, seconds):
+        self.current += float(seconds)
+
+
+class FakeRPC:
+    def __init__(self, fail_connect=False, fail_update=False, fail_clear=False):
+        self.fail_connect = fail_connect
+        self.fail_update = fail_update
+        self.fail_clear = fail_clear
+        self.connect_calls = 0
+        self.update_calls = []
+        self.clear_calls = 0
+        self.close_calls = 0
+
+    def connect(self):
+        self.connect_calls += 1
+        if self.fail_connect:
+            raise RuntimeError("discord closed")
+
+    def update(self, **payload):
+        if self.fail_update:
+            raise RuntimeError("discord lost")
+        self.update_calls.append(payload)
+
+    def clear(self):
+        self.clear_calls += 1
+        if self.fail_clear:
+            raise RuntimeError("clear failed")
+
+    def close(self):
+        self.close_calls += 1
+
+
+class FakeRPCFactory:
+    def __init__(self, *rpcs):
+        self.rpcs = list(rpcs)
+        self.instances = []
+
+    def __call__(self, _client_id):
+        if not self.rpcs:
+            raise AssertionError("No fake RPC instance available")
+        rpc = self.rpcs.pop(0)
+        self.instances.append(rpc)
+        return rpc
+
+
+def sample_state():
+    return {
+        "is_in_vehicle": True,
+        "vehicle_type": "tank",
+        "vehicle_slug": "us_m1a1_hc_abrams",
+        "vehicle_name": "M1A1 HC",
+        "vehicle_image_url": "https://example.com/m1.png",
+        "vehicle_image_status": "resolved_direct",
+        "in_match": True,
+        "main_objective": "Capture the enemy point",
+        "in_map": True,
+        "current_map": "Kursk",
+        "kill_count": 2,
+        "team_status": "Winning",
+        "health_status": "3/4 Crew",
+    }
 
 
 class RuntimeBehaviorTests(unittest.TestCase):
@@ -25,43 +101,232 @@ class RuntimeBehaviorTests(unittest.TestCase):
                 check_process_running=lambda: False,
                 idle_interval=17,
             ),
-            rpc_factory=lambda _: (_ for _ in ()).throw(AssertionError("RPC should not connect")),
+            player_name="Pilot",
         )
 
         self.assertEqual(app.tick(), 17)
+        self.assertEqual(app.runtime_state, "game_not_running")
 
-    def test_local_mode_raises_friendly_error_when_indicators_unavailable(self):
-        app = WarThunderRPCApp(RuntimeOptions(mode="local"), player_name="Pilot")
+    def test_local_mode_no_longer_raises_when_indicators_unavailable(self):
+        app = WarThunderRPCApp(
+            RuntimeOptions(mode="local", prompt_for_username=False, check_process_running=lambda: True),
+            player_name="Pilot",
+        )
         with patch("warthunder_rpc.runtime.requests.get", side_effect=RuntimeError("boom")):
-            with self.assertRaisesRegex(RuntimeError, "War Thunder is not running"):
-                app.get_json_data("indicators")
+            self.assertIsNone(app.get_json_data("indicators"))
+
+    def test_game_exit_clears_presence_and_keeps_waiting(self):
+        clock = FakeClock()
+        rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(rpc),
+        )
+        app.get_game_state = lambda: sample_state()
+        app.tick()
+
+        app.check_process_running = lambda: False
+        delay = app.tick()
+
+        self.assertEqual(delay, app.options.idle_interval)
+        self.assertEqual(app.runtime_state, "game_not_running")
+        self.assertEqual(rpc.clear_calls, 1)
+        self.assertGreaterEqual(rpc.close_calls, 1)
+
+    def test_loading_gap_preserves_last_presence_during_grace_period(self):
+        clock = FakeClock()
+        rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                telemetry_grace_seconds=20,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(rpc),
+        )
+        states = iter([sample_state(), None])
+        app.get_game_state = lambda: next(states)
+
+        app.tick()
+        clock.advance(5)
+        app.tick()
+
+        self.assertEqual(app.runtime_state, "loading_transition")
+        self.assertEqual(rpc.clear_calls, 0)
+        self.assertTrue(app.presence_active)
+
+    def test_long_telemetry_gap_clears_presence(self):
+        clock = FakeClock()
+        rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                telemetry_grace_seconds=5,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(rpc),
+        )
+        app.get_game_state = lambda: sample_state()
+        app.tick()
+
+        app.get_game_state = lambda: None
+        clock.advance(10)
+        app.tick()
+
+        self.assertEqual(app.runtime_state, "telemetry_unavailable")
+        self.assertEqual(rpc.clear_calls, 1)
+
+    def test_discord_not_running_is_retried_without_crashing(self):
+        clock = FakeClock()
+        failing_rpc = FakeRPC(fail_connect=True)
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                rpc_retry_interval=5,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(failing_rpc),
+        )
+        app.get_game_state = lambda: sample_state()
+
+        delay = app.tick()
+
+        self.assertEqual(delay, app.options.active_interval)
+        self.assertEqual(app.runtime_state, "discord_unavailable")
+        self.assertIsNotNone(app.last_presence_payload)
+
+    def test_discord_reconnect_publishes_cached_state(self):
+        clock = FakeClock()
+        failing_rpc = FakeRPC(fail_connect=True)
+        working_rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                rpc_retry_interval=5,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(failing_rpc, working_rpc),
+        )
+        app.get_game_state = lambda: sample_state()
+
+        app.tick()
+        clock.advance(6)
+        app.tick()
+
+        self.assertEqual(app.runtime_state, "match")
+        self.assertEqual(len(working_rpc.update_calls), 1)
+        self.assertTrue(app.presence_active)
+
+    def test_discord_drop_mid_session_recovers_after_backoff(self):
+        clock = FakeClock()
+        first_rpc = FakeRPC(fail_update=True)
+        second_rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                rpc_retry_interval=5,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(first_rpc, second_rpc),
+        )
+        app.get_game_state = lambda: sample_state()
+
+        app.tick()
+        self.assertEqual(app.runtime_state, "discord_unavailable")
+
+        clock.advance(6)
+        app.tick()
+
+        self.assertEqual(app.runtime_state, "match")
+        self.assertEqual(len(second_rpc.update_calls), 1)
+
+    def test_kill_tracker_resets_only_after_confirmed_game_exit(self):
+        clock = FakeClock()
+        rpc = FakeRPC()
+        app = WarThunderRPCApp(
+            RuntimeOptions(
+                prompt_for_username=False,
+                check_process_running=lambda: True,
+                telemetry_grace_seconds=20,
+                time_provider=clock.now,
+                sleep_provider=clock.sleep,
+            ),
+            player_name="Pilot",
+            rpc_factory=FakeRPCFactory(rpc),
+        )
+        app.kill_tracker.start_session(seed_damage_id=10)
+        app.kill_tracker.kill_count = 3
+        app.last_good_state = sample_state()
+        app.last_presence_payload = app.build_presence_data(sample_state())
+        app.last_telemetry_ok_at = clock.now()
+
+        app._handle_telemetry_gap()
+        self.assertTrue(app.kill_tracker.session_active)
+        self.assertEqual(app.kill_tracker.kill_count, 3)
+
+        app.check_process_running = lambda: False
+        app.tick()
+        self.assertFalse(app.kill_tracker.session_active)
+        self.assertEqual(app.kill_tracker.kill_count, 0)
 
 
 class PresencePayloadTests(unittest.TestCase):
     def test_match_payload_prefers_vehicle_image(self):
-        app = WarThunderRPCApp(RuntimeOptions(mode="local"), player_name="Pilot")
+        app = WarThunderRPCApp(RuntimeOptions(mode="local", prompt_for_username=False), player_name="Pilot")
         app.clock_timer = 123
-        state = {
-            "is_in_vehicle": True,
-            "vehicle_type": "tank",
-            "vehicle_slug": "us_m1a1_hc_abrams",
-            "vehicle_name": "M1A1 HC",
-            "vehicle_image_url": "https://example.com/m1.png",
-            "vehicle_image_status": "resolved_direct",
-            "in_match": True,
-            "main_objective": "Capture the enemy point",
-            "in_map": True,
-            "current_map": "Kursk",
-            "kill_count": 2,
-            "team_status": "Winning",
-            "health_status": "3/4 Crew",
-        }
 
-        payload = app.build_presence_data(state)
+        payload = app.build_presence_data(sample_state())
 
         self.assertEqual(payload["large_image"], "https://example.com/m1.png")
         self.assertEqual(payload["large_text"], "Kursk")
         self.assertEqual(payload["details"], "Ground Battle, 2 Kills")
+
+
+class ServiceSupervisionTests(unittest.TestCase):
+    def test_service_launches_worker_task_when_worker_missing(self):
+        with patch("warthunder_rpc.windows_service.build_service_logger", return_value=logging.getLogger("test.service")):
+            service = WarThunderRPCService(None)
+            service.is_worker_running = lambda: False
+            launches = []
+            service.launch_worker = lambda: launches.append("run") or True
+
+            delay = service.supervise_worker()
+
+            self.assertEqual(delay, service.idle_check_interval)
+            self.assertEqual(launches, ["run"])
+
+    def test_service_skips_launch_when_worker_is_already_running(self):
+        with patch("warthunder_rpc.windows_service.build_service_logger", return_value=logging.getLogger("test.service")):
+            service = WarThunderRPCService(None)
+            service.is_worker_running = lambda: True
+            launches = []
+            service.launch_worker = lambda: launches.append("run") or True
+
+            delay = service.supervise_worker()
+
+            self.assertEqual(delay, service.check_interval)
+            self.assertEqual(launches, [])
 
 
 if __name__ == "__main__":

--- a/warthunder_rpc/installer.py
+++ b/warthunder_rpc/installer.py
@@ -15,6 +15,8 @@ from .user_config import read_username, write_username
 
 
 VERSION = "1.0.0"
+WORKER_TASK_NAME = "WarThunderRPCWorker"
+WORKER_ARGUMENT = "--worker"
 
 
 def get_service_status():
@@ -43,6 +45,13 @@ def is_admin():
 
 def run_as_admin():
     ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, " ".join(sys.argv), None, 1)
+
+
+def get_current_user():
+    try:
+        return subprocess.run(["whoami"], check=True, capture_output=True, text=True).stdout.strip()
+    except Exception:
+        return os.environ.get("USERNAME", "")
 
 
 class UsernameDialog:
@@ -212,6 +221,27 @@ class InstallerGUI:
             current_exe = sys.executable if getattr(sys, "frozen", False) else sys.argv[0]
             installed_exe = os.path.join(install_dir, "WarThunderRPC.exe")
             shutil.copy2(current_exe, installed_exe)
+            worker_cmd = f'"{installed_exe}" {WORKER_ARGUMENT}'
+            current_user = get_current_user()
+
+            subprocess.run(
+                [
+                    "schtasks",
+                    "/create",
+                    "/f",
+                    "/tn",
+                    WORKER_TASK_NAME,
+                    "/sc",
+                    "ONLOGON",
+                    "/tr",
+                    worker_cmd,
+                    "/ru",
+                    current_user,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
             try:
                 if win32serviceutil.QueryServiceStatus("WarThunderRPC")[1] == win32service.SERVICE_RUNNING:
@@ -264,6 +294,12 @@ class InstallerGUI:
                 text=True,
             )
             subprocess.run(["sc", "start", "WarThunderRPC"], check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["schtasks", "/run", "/tn", WORKER_TASK_NAME],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
             messagebox.showinfo("Success", "Service installed and started successfully!")
         except Exception as exc:
             messagebox.showerror("Installation Error", f"Failed to install service:\n{exc}")
@@ -292,6 +328,11 @@ class InstallerGUI:
                 self.status_label.config(text="Removing service...", fg="orange")
                 self.root.update()
                 subprocess.run(["sc", "delete", "WarThunderRPC"], check=True)
+
+            try:
+                subprocess.run(["schtasks", "/delete", "/f", "/tn", WORKER_TASK_NAME], check=True)
+            except Exception:
+                pass
 
             install_dir = os.path.join(os.getenv("PROGRAMFILES"), "WarThunderRPC")
             if os.path.exists(install_dir):

--- a/warthunder_rpc/launcher.py
+++ b/warthunder_rpc/launcher.py
@@ -3,6 +3,8 @@ import sys
 import servicemanager
 
 from .installer import InstallerGUI, is_admin, run_as_admin
+from .local import main as local_main
+from .worker import main as worker_main
 from .windows_service import WarThunderRPCService
 
 
@@ -16,6 +18,14 @@ def main():
 
         if sys.argv[1] == "--run":
             WarThunderRPCService(None).run_service()
+            return
+
+        if sys.argv[1] == "--worker":
+            worker_main()
+            return
+
+        if sys.argv[1] == "--local":
+            local_main()
             return
 
         if sys.argv[1] == "--install" and is_admin():

--- a/warthunder_rpc/runtime.py
+++ b/warthunder_rpc/runtime.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+import psutil
 import requests
 from PIL import Image
 from pypresence import Presence
@@ -36,6 +37,12 @@ class RuntimeOptions:
     stop_requested: Optional[Callable[[], bool]] = None
     active_interval: int = 3
     idle_interval: int = 10
+    telemetry_grace_seconds: int = 20
+    rpc_retry_interval: int = 5
+    clear_presence_on_game_exit: bool = True
+    discord_retry_backoff_max: int = 60
+    time_provider: Callable[[], float] = time.time
+    sleep_provider: Callable[[float], None] = time.sleep
 
 
 class WarThunderRPCApp:
@@ -51,11 +58,22 @@ class WarThunderRPCApp:
         self.rpc_factory = rpc_factory
         self.client_id = "1211769535468937237"
         self.rpc = None
-        self.clock_timer = int(time.time())
+        self.clock_timer = int(self.now())
         self.base_url = "http://127.0.0.1:8111"
-        self.check_process_running = self.options.check_process_running
+        self.check_process_running = self.options.check_process_running or self._is_aces_running
         self.stop_requested = self.options.stop_requested or (lambda: False)
         self.image_resolver = VehicleImageResolver(logger=self.logger)
+
+        self.runtime_state = "game_not_running"
+        self.last_good_state = None
+        self.last_presence_payload = None
+        self.last_telemetry_ok_at = None
+        self.last_rpc_error_at = None
+        self.presence_active = False
+        self.rpc_connected = False
+        self._rpc_retry_delay = max(1, self.options.rpc_retry_interval)
+        self._next_rpc_connect_at = 0.0
+        self._logged_messages = set()
 
         if player_name is None:
             if self.options.prompt_for_username:
@@ -66,22 +84,81 @@ class WarThunderRPCApp:
         self.player_name = player_name
         self.kill_tracker = KillTracker(PlayerIdentity(self.player_name))
 
+    def now(self):
+        return float(self.options.time_provider())
+
+    @staticmethod
+    def _is_aces_running():
+        for process in psutil.process_iter(["name"]):
+            try:
+                if (process.info.get("name") or "").lower() == "aces.exe":
+                    return True
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+        return False
+
+    def _log_once(self, key, level, message, *args):
+        if key in self._logged_messages:
+            return
+        self._logged_messages.add(key)
+        self.logger.log(level, message, *args)
+
+    def _clear_log_once(self, *keys):
+        for key in keys:
+            self._logged_messages.discard(key)
+
+    def _set_runtime_state(self, state):
+        self.runtime_state = state
+
+    def _mark_rpc_unavailable(self, exc):
+        self.last_rpc_error_at = self.now()
+        self.rpc_connected = False
+        self._set_runtime_state("discord_unavailable")
+        self._log_once("discord_unavailable", logging.WARNING, "Discord RPC unavailable: %s", exc)
+        self._next_rpc_connect_at = self.now() + self._rpc_retry_delay
+        self._rpc_retry_delay = min(
+            max(1, self.options.discord_retry_backoff_max),
+            max(1, self._rpc_retry_delay * 2),
+        )
+        self.disconnect_rpc()
+
+    def _reset_rpc_backoff(self):
+        self._rpc_retry_delay = max(1, self.options.rpc_retry_interval)
+        self._next_rpc_connect_at = 0.0
+        self._clear_log_once("discord_unavailable")
+
     def connect_rpc(self):
         if self.rpc is not None:
-            return
+            return True
 
-        self.rpc = self.rpc_factory(self.client_id)
-        self.rpc.connect()
-        self.clock_timer = int(time.time())
+        if self.now() < self._next_rpc_connect_at:
+            return False
+
+        try:
+            self.rpc = self.rpc_factory(self.client_id)
+            self.rpc.connect()
+        except Exception as exc:
+            self._mark_rpc_unavailable(exc)
+            return False
+
+        self.rpc_connected = True
+        self.clock_timer = int(self.now())
+        self._reset_rpc_backoff()
+        self._log_once("rpc_recovered", logging.INFO, "Discord RPC connected")
+        return True
 
     def disconnect_rpc(self):
         if self.rpc is None:
+            self.rpc_connected = False
             return
 
         try:
             self.rpc.close()
+        except Exception as exc:
+            self.logger.debug("Error closing Discord RPC: %s", exc)
         finally:
             self.rpc = None
+            self.rpc_connected = False
 
     def fetch_hudmsg(self, last_evt=0, last_dmg=0):
         try:
@@ -153,10 +230,6 @@ class WarThunderRPCApp:
             response.raise_for_status()
             return json.loads(response.text)
         except Exception as exc:
-            if endpoint == "indicators" and self.options.mode == "local":
-                raise RuntimeError(
-                    "War Thunder is not running, or port 8111 is already occupied!"
-                ) from exc
             self.logger.debug("Error fetching %s: %s", endpoint, exc)
             return None
 
@@ -308,39 +381,131 @@ class WarThunderRPCApp:
 
         return {**base_presence, "state": "Unknown vehicle", "details": "In-game"}
 
+    def _publish_presence(self, presence_data):
+        self.last_presence_payload = presence_data
+        if not self.connect_rpc():
+            return False
+
+        try:
+            self.rpc.update(**presence_data)
+        except Exception as exc:
+            self._mark_rpc_unavailable(exc)
+            return False
+
+        self.presence_active = True
+        self.rpc_connected = True
+        self._clear_log_once("rpc_recovered")
+        self.logger.info("Updated presence: %s", presence_data)
+        return True
+
+    def clear_presence(self, reason=""):
+        if self.rpc is None or not self.presence_active:
+            self.presence_active = False
+            return True
+
+        try:
+            self.rpc.clear()
+            self._log_once(
+                f"presence_cleared:{reason or 'default'}",
+                logging.INFO,
+                "Cleared Discord presence%s",
+                f" ({reason})" if reason else "",
+            )
+        except Exception as exc:
+            self._mark_rpc_unavailable(exc)
+            return False
+
+        self.presence_active = False
+        return True
+
+    def _reset_session_state(self):
+        self.kill_tracker.reset_session()
+        self.last_good_state = None
+        self.last_presence_payload = None
+        self.last_telemetry_ok_at = None
+
+    def _handle_game_not_running(self):
+        self._set_runtime_state("game_not_running")
+        self._log_once("game_missing", logging.INFO, "War Thunder not detected; waiting")
+        self._clear_log_once("telemetry_gap", "loading_transition")
+        if self.options.clear_presence_on_game_exit:
+            self.clear_presence("game closed")
+        self.disconnect_rpc()
+        self._reset_session_state()
+
+    def _handle_telemetry_gap(self):
+        telemetry_age = None
+        if self.last_telemetry_ok_at is not None:
+            telemetry_age = self.now() - self.last_telemetry_ok_at
+
+        in_grace_period = (
+            self.last_good_state is not None
+            and telemetry_age is not None
+            and telemetry_age <= self.options.telemetry_grace_seconds
+        )
+
+        if in_grace_period:
+            self._set_runtime_state("loading_transition")
+            self._log_once(
+                "loading_transition",
+                logging.INFO,
+                "Telemetry temporarily unavailable; preserving last known state",
+            )
+            self._clear_log_once("telemetry_gap")
+            if self.last_presence_payload is not None:
+                self._publish_presence(self.last_presence_payload)
+            return
+
+        self._set_runtime_state("telemetry_unavailable")
+        self._log_once(
+            "telemetry_gap",
+            logging.INFO,
+            "Telemetry unavailable while War Thunder is running; waiting for recovery",
+        )
+        self._clear_log_once("loading_transition")
+        if self.options.clear_presence_on_game_exit:
+            self.clear_presence("telemetry unavailable")
+        self.disconnect_rpc()
+
+    @staticmethod
+    def _classify_state(state):
+        if state["in_map"] and state["in_match"]:
+            return "match"
+        if state["is_in_vehicle"] and state["in_map"]:
+            return "test_drive"
+        return "hangar"
+
+    def _handle_live_state(self, state):
+        self.last_good_state = state
+        self.last_telemetry_ok_at = self.now()
+        self._clear_log_once("game_missing", "telemetry_gap", "loading_transition")
+        self._set_runtime_state(self._classify_state(state))
+        self._publish_presence(self.build_presence_data(state))
+
     def tick(self):
-        if self.check_process_running and not self.check_process_running():
-            self.disconnect_rpc()
+        if not self.check_process_running():
+            self._handle_game_not_running()
             return self.options.idle_interval
 
-        self.connect_rpc()
         state = self.get_game_state()
         if state is None:
+            self._handle_telemetry_gap()
             return self.options.active_interval
 
-        presence_data = self.build_presence_data(state)
-        self.rpc.update(**presence_data)
-        self.logger.info("Updated presence: %s", presence_data)
+        self._handle_live_state(state)
         return self.options.active_interval
 
     def run_forever(self):
         while not self.stop_requested():
             try:
                 delay = self.tick()
-            except RuntimeError as exc:
-                if self.options.mode == "local":
-                    print(str(exc))
-                    time.sleep(1)
-                    print("Exiting...")
-                    time.sleep(4)
-                    break
-                self.logger.error("Runtime error: %s", exc)
-                delay = self.options.idle_interval
             except Exception as exc:
                 self.logger.error("Error updating presence: %s", exc)
                 delay = self.options.active_interval
 
             if delay > 0 and not self.stop_requested():
-                time.sleep(delay)
+                self.options.sleep_provider(delay)
 
+        if self.options.clear_presence_on_game_exit:
+            self.clear_presence("shutdown")
         self.disconnect_rpc()

--- a/warthunder_rpc/windows_service.py
+++ b/warthunder_rpc/windows_service.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import socket
+import subprocess
+import time
 
 import psutil
 import servicemanager
@@ -8,7 +10,9 @@ import win32event
 import win32service
 import win32serviceutil
 
-from .runtime import RuntimeOptions, WarThunderRPCApp
+
+WORKER_TASK_NAME = "WarThunderRPCWorker"
+WORKER_ARGUMENT = "--worker"
 
 
 def build_service_logger():
@@ -37,7 +41,7 @@ def build_service_logger():
 class WarThunderRPCService(win32serviceutil.ServiceFramework):
     _svc_name_ = "WarThunderRPC"
     _svc_display_name_ = "War Thunder Discord Rich Presence"
-    _svc_description_ = "Provides Discord Rich Presence integration for War Thunder"
+    _svc_description_ = "Supervises the War Thunder Discord Rich Presence worker"
 
     def __init__(self, args):
         if args is not None:
@@ -52,6 +56,8 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         self.logger = build_service_logger()
         self.check_interval = 3
         self.idle_check_interval = 10
+        self.worker_task_name = WORKER_TASK_NAME
+        self._worker_launch_logged = False
         self.logger.info("Service initialized. Running as service: %s", self.is_running_as_service)
 
     def SvcStop(self):
@@ -80,30 +86,54 @@ class WarThunderRPCService(win32serviceutil.ServiceFramework):
         return win32event.WaitForSingleObject(self.stop_event, 1000) == win32event.WAIT_OBJECT_0
 
     @staticmethod
-    def is_aces_running():
-        for process in psutil.process_iter(["name"]):
+    def is_worker_running():
+        for process in psutil.process_iter(["cmdline"]):
             try:
-                if (process.info.get("name") or "").lower() == "aces.exe":
-                    return True
+                cmdline = process.info.get("cmdline") or []
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 continue
+
+            if WORKER_ARGUMENT in cmdline:
+                return True
         return False
 
-    def run_service(self):
-        app = WarThunderRPCApp(
-            RuntimeOptions(
-                mode="service",
-                prompt_for_username=False,
-                check_process_running=self.is_aces_running,
-                logger=self.logger,
-                stop_requested=self.should_stop,
-                active_interval=self.check_interval,
-                idle_interval=self.idle_check_interval,
-            )
-        )
-
+    def launch_worker(self):
         try:
-            app.run_forever()
+            subprocess.run(
+                ["schtasks", "/run", "/tn", self.worker_task_name],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception as exc:
+            if not self._worker_launch_logged:
+                self.logger.error("Worker launch failure: %s", exc)
+                self._worker_launch_logged = True
+            return False
+
+        self._worker_launch_logged = False
+        self.logger.info("Requested worker start via scheduled task")
+        return True
+
+    def supervise_worker(self):
+        if self.is_worker_running():
+            self._worker_launch_logged = False
+            return self.check_interval
+
+        self.launch_worker()
+        return self.idle_check_interval
+
+    def _wait(self, seconds):
+        if seconds <= 0:
+            return
+        if self.is_running_as_service:
+            win32event.WaitForSingleObject(self.stop_event, int(seconds * 1000))
+            return
+        time.sleep(seconds)
+
+    def run_service(self):
+        try:
+            while not self.should_stop():
+                self._wait(self.supervise_worker())
         finally:
-            app.disconnect_rpc()
             self.logger.info("Service stopped")

--- a/warthunder_rpc/worker.py
+++ b/warthunder_rpc/worker.py
@@ -1,0 +1,19 @@
+import logging
+
+from .runtime import RuntimeOptions, WarThunderRPCApp
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    app = WarThunderRPCApp(
+        RuntimeOptions(
+            mode="worker",
+            prompt_for_username=False,
+            logger=logging.getLogger("warthunder_rpc.worker"),
+        )
+    )
+    app.run_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
- describe how the runtime now stays alive through telemetry gaps, game exit, and Discord absence while keeping presence clearing reliable
- mention the new worker/service split and resilience options for RPC retries and telemetry grace

Testing
- Not run (not requested)